### PR TITLE
DEVOPS-2289: ElasticCache: Add single reader_endpoint_address to aws_elasticache_replication_group

### DIFF
--- a/aws/data_source_aws_elasticache_replication_group.go
+++ b/aws/data_source_aws_elasticache_replication_group.go
@@ -47,6 +47,10 @@ func dataSourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
+			"reader_endpoint_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"number_cache_clusters": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -124,6 +128,7 @@ func dataSourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta i
 		if err := d.Set("read_endpoint_addresses", flattenStringList(rEndpoints)); err != nil {
 			return fmt.Errorf("error setting read_endpoint_addresses: %s", err)
 		}
+		d.Set("reader_endpoint_address", rg.NodeGroups[0].ReaderEndpoint.Address)
 	}
 	d.Set("number_cache_clusters", len(rg.MemberClusters))
 	if err := d.Set("member_clusters", flattenStringList(rg.MemberClusters)); err != nil {

--- a/aws/data_source_aws_elasticache_replication_group_test.go
+++ b/aws/data_source_aws_elasticache_replication_group_test.go
@@ -24,6 +24,7 @@ func TestAccDataSourceAwsElasticacheReplicationGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "port", "6379"),
 					resource.TestCheckResourceAttrSet("data.aws_elasticache_replication_group.bar", "primary_endpoint_address"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "read_endpoint_addresses", "2"),
+					resource.TestCheckResourceAttrSet("data.aws_elasticache_replication_group.bar", "reader_endpoint_address"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "member_clusters.#", "2"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "node_type", "cache.m1.small"),

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -153,6 +153,10 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"reader_endpoint_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"replication_group_description": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -478,6 +482,7 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 		} else {
 			d.Set("port", rgp.NodeGroups[0].PrimaryEndpoint.Port)
 			d.Set("primary_endpoint_address", rgp.NodeGroups[0].PrimaryEndpoint.Address)
+			d.Set("reader_endpoint_address", rgp.NodeGroups[0].ReaderEndpoint.Address)
 		}
 
 		d.Set("auto_minor_version_upgrade", c.AutoMinorVersionUpgrade)

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -305,6 +305,8 @@ func TestAccAWSElasticacheReplicationGroup_multiAzInVpc(t *testing.T) {
 						"aws_elasticache_replication_group.bar", "snapshot_retention_limit", "7"),
 					resource.TestCheckResourceAttrSet(
 						"aws_elasticache_replication_group.bar", "primary_endpoint_address"),
+					resource.TestCheckResourceAttrSet(
+						"aws_elasticache_replication_group.bar", "reader_endpoint_address"),
 				),
 			},
 		},
@@ -332,6 +334,8 @@ func TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2(t *testing.T) {
 						"aws_elasticache_replication_group.bar", "snapshot_retention_limit", "7"),
 					resource.TestCheckResourceAttrSet(
 						"aws_elasticache_replication_group.bar", "primary_endpoint_address"),
+					resource.TestCheckResourceAttrSet(
+						"aws_elasticache_replication_group.bar", "reader_endpoint_address"),
 				),
 			},
 		},

--- a/website/docs/d/elasticache_replication_group.html.markdown
+++ b/website/docs/d/elasticache_replication_group.html.markdown
@@ -40,3 +40,4 @@ In addition to all arguments above, the following attributes are exported:
 * `configuration_endpoint_address` - The configuration endpoint address to allow host discovery.
 * `primary_endpoint_address` - The endpoint of the primary node in this node group (shard).
 * `read_endpoint_addresses` - Reader endpoints of the nodes in this node group.
+* `reader_endpoint_address` - The endpoint of the reader node in this node group (shard).

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -147,6 +147,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the ElastiCache Replication Group.
 * `configuration_endpoint_address` - The address of the replication group configuration endpoint when cluster mode is enabled.
 * `primary_endpoint_address` - (Redis only) The address of the endpoint for the primary node in the replication group, if the cluster mode is disabled.
+* `reader_endpoint_address` - (Redis only) The address of the endpoint for the reader node in the replication group, if the cluster mode is disabled.
 * `member_clusters` - The identifiers of all the nodes that are part of this replication group.
 
 ## Timeouts


### PR DESCRIPTION
### Why do we need these changes
We had two incidents caused by ElastiCache writer instance for high network and CPU usage. By redirecting all read requests to the read-only Redis replicas, is a quick way to ease the CPU and bandwidth usage of the writer/primary node.


### Fix
AWS recently added a single reader endpoint for AWS ElastiCache Redis so that we can only use a single reader endpoint to connect to your Redis read replicas:
https://aws.amazon.com/about-aws/whats-new/2019/06/amazon-elasticache-launches-reader-endpoint-for-redis/

Although, as the official Terraform Provider (for v0.11) is not supporting the single reader endpoint at the moment, we have to modify our fork of the Terraform AWS Provider to return this single reader endpoint.


### Changelog
- `resource/aws_elasticache_replication_group`: Add reader_endpoint_address attribute
- `data-source/aws_elasticache_replication_group`: Add reader_endpoint_address attribute


### Reference
On the official repo of the Terraform AWS Provider, there is an [open issue](https://github.com/terraform-providers/terraform-provider-aws/issues/10519) regarding the above use-case.
Regarding this PR, I cherry-picked the changes from this PR (and more specifically [this commit](https://github.com/terraform-providers/terraform-provider-aws/pull/9979/commits/62bdba4fd77e83534fa0fc31fcde43ea89a1f72a)):
https://github.com/terraform-providers/terraform-provider-aws/pull/9979

The changes in this PR will let our (forked) Terraform AWS Provider to return this single endpoint (both with Terraform's `resource` and `data` definitions).


### In Action
With the newly built binary of the Terraform AWS Provider, and by changing the custom JSON file with the new attribute:
```
...
```

a `terraform plan` will produce the following changelog (in this example we use the `Argentina` stack):

<details>
  <summary>Output</summary>
  
  ```
...
  ```
</details>

So, based on the above output, it will replace the endpoints of all the reader hostnames and replace it with the single reader endpoint that AWS will take care of adding/removing endpoints in real-time.